### PR TITLE
feat: substitute static strings at generation time for iOS and Android

### DIFF
--- a/crowdin/codegen_localization.py
+++ b/crowdin/codegen_localization.py
@@ -17,6 +17,7 @@ from generate_shared import (
     load_parsed_translations,
     print_progress,
     print_success,
+    replace_glossary_variables,
     run_main
 )
 
@@ -168,13 +169,6 @@ def generate_with_types() -> str:
     for (arg_name, arg_type), type_name in WITH_MAP.items():
         lines.append(f"type {type_name} = {{{arg_name}: {arg_type}}};")
     return "\n".join(lines)
-
-
-def replace_glossary_variables(text: str, glossary_dict: Dict[str, str]) -> str:
-    """Replace glossary variables like {app_name} with their actual values."""
-    for glossary_key, glossary_value in glossary_dict.items():
-        text = text.replace("{" + glossary_key + "}", glossary_value)
-    return text
 
 
 def snake_to_camel(snake_str: str) -> str:

--- a/crowdin/generate_android_strings.py
+++ b/crowdin/generate_android_strings.py
@@ -8,13 +8,16 @@ from generate_shared import (
     clean_string,
     print_progress,
     print_success,
+    replace_glossary_variables,
     run_main
 )
 
 # Variables that should be treated as numeric (using %d)
 NUMERIC_VARIABLES = ['count', 'found_count', 'total_count']
 
-AUTO_REPLACE_STATIC_STRINGS = False
+# Note: The client code no longer substitutes these constants at runtime, so turning this back
+# off would leave `{app_name}` etc. visible in the UI
+AUTO_REPLACE_STATIC_STRINGS = True
 
 
 def convert_placeholders(text: str) -> str:
@@ -56,7 +59,15 @@ def generate_android_xml(
         if trans_data['type'] == 'plural':
             result += f'    <plurals name="{resname}">\n'
             for form, value in trans_data['forms'].items():
-                escaped_value = clean_string(convert_placeholders(value), True, glossary_dict, {})
+                # Note: the glossary has to be applied *before* converting placeholders, otherwise
+                # `{app_name}` has already become `%1$s` and can never be replaced (which would
+                # also shift the positional indexes of the remaining placeholders)
+                escaped_value = clean_string(
+                    convert_placeholders(replace_glossary_variables(value, glossary_dict)),
+                    True,
+                    {},
+                    {}
+                )
                 result += f'        <item quantity="{form}">{escaped_value}</item>\n'
             result += '    </plurals>\n'
         else:

--- a/crowdin/generate_ios_strings.py
+++ b/crowdin/generate_ios_strings.py
@@ -12,7 +12,9 @@ from generate_shared import (
     run_main
 )
 
-AUTO_REPLACE_STATIC_STRINGS = False
+# Note: The client code no longer substitutes these constants at runtime, so turning this back
+# off would leave `{app_name}` etc. visible in the UI
+AUTO_REPLACE_STATIC_STRINGS = True
 
 # It seems that Xcode uses different language codes and doesn't support all of the languages we get from Crowdin
 # (at least in the variants that Crowdin is specifying them in) so need to map/exclude them in order to build correctly

--- a/crowdin/generate_shared.py
+++ b/crowdin/generate_shared.py
@@ -54,7 +54,18 @@ def load_parsed_translations(input_file: str) -> Dict[str, Any]:
         return json.load(f)
 
 
+def replace_glossary_variables(text: str, glossary_dict: Dict[str, str]) -> str:
+    """Replace glossary variables like {app_name} with their actual values."""
+    for glossary_key, glossary_value in glossary_dict.items():
+        text = text.replace("{" + glossary_key + "}", glossary_value)
+    return text
+
+
 def clean_string(text: str, is_android: bool, glossary_dict: Dict[str, str], extra_replace_dict: Dict[str, str]):
+    # Replace the constants (from crowdin's glossary) before any escaping so that the values
+    # themselves get escaped the same way the rest of the string does
+    text = replace_glossary_variables(text, glossary_dict)
+
     if is_android:
         # Note: any changes done for all platforms needs most likely to be done on crowdin side.
         # So we don't want to replace -&gt; with → for instance, we want the crowdin strings to not have those at all.
@@ -77,11 +88,6 @@ def clean_string(text: str, is_android: bool, glossary_dict: Dict[str, str], ext
         text = html.unescape(text)          # Unescape any HTML escaping
 
     text = text.strip()               # Strip whitespace
-
-    # replace all the defined constants (from crowdin's glossary) in the string
-    for glossary_key in glossary_dict:
-        text = text.replace("{" + glossary_key + "}",
-                            glossary_dict[glossary_key])
 
     # if extra_replace_dict has keys, replace those too
     for extra_key in extra_replace_dict:


### PR DESCRIPTION
Enables AUTO_REPLACE_STATIC_STRINGS for both mobile generators, so they match what Desktop has always done. Verified against a full Crowdin export: the two constants files are byte-identical and the generated strings differ only by the substitution.

- Apply the glossary before converting Android plural placeholders. Previously the tokens had already become %N$s, so glossary tokens inside plurals were never substituted and kept consuming a positional argument. proBadgesSent ("{total} {pro} Badge Sent") is the only affected plural in the project, and it drops an argument as a result — its pluralStringResource call has to change in lockstep or Android throws MissingFormatArgumentException.
- Apply the glossary before escaping in clean_string, so substituted values are escaped like the text around them.
- Move replace_glossary_variables into generate_shared and drop Desktop's copy. Desktop's generated output is byte-identical, including against the artefacts the check_for_crowdin_updates run produced.

The flag is no longer a safe toggle: the clients no longer substitute these at runtime, so turning it back off leaves {app_name} visible in the UI. It's kept as a constant rather than deleted so the behaviour stays greppable.